### PR TITLE
Optimize Sleep TK

### DIFF
--- a/apps/sleep_tk.py
+++ b/apps/sleep_tk.py
@@ -57,16 +57,6 @@ icon = (
     b']'
 )
 
-# HARDCODED VARIABLES:
-_ON = const(1)
-_OFF = const(0)
-_SLEEPING = const(0)
-_RINGING = const(1)
-_SETTINGS1 = const(2)
-_SETTINGS2 = const(3)
-_FONT = fonts.sans18
-_FONT_COLOR = const(0xf800)  # red font to reduce eye strain at night
-_TIMESTAMP = const(946684800)  # unix time and time used by wasp os don't have the same reference date
 
 ## USER SETTINGS #################################
 _KILL_BT = const(0)
@@ -99,6 +89,52 @@ _SLEEP_GOAL_CYCLE = const(5)
 # to suggest best wake up time to user when setting the alarm. (default: 5)
 ##################################################
 
+# HARDCODED VARIABLES:
+_HEART_RATE_UNKNOWN = const(1) # Use HR of 1 as unknown
+
+# Pages
+_PAGE_SLEEPING = const(0)
+_PAGE_RINGING = const(1)
+_PAGE_SETTINGS1 = const(2)
+_PAGE_SETTINGS2 = const(3)
+
+_FONT = fonts.sans18
+_FONT_COLOR = const(0xf800)  # red font to reduce eye strain at night
+_TIMESTAMP = const(946684800)  # unix time and time used by wasp os don't have the same reference date
+
+# States :
+_IDX_STATE_1 = const(0) # App States 1 (8 bit register)
+_IDX_STATE_2 = const(1) # App States 2 (8 bit register)
+_IDX_STATE_3 = const(2) # App States 3 (8 bit register)
+_IDX_ALARM_HOUR = const(3) # Alarm hour (8 bit int)
+_IDX_ALARM_MIN = const(4) # Alarm min (8 bit int)
+_IDX_LAST_HR = const(5) # Last Heart Rate (8 bit int)
+_IDX_LAST_HR_PRINTED = const(6) # Last Heart Rate Printed (8 bit int)
+
+# App States 1 (8 bit register)
+_ALARM_ENABLED = const(0x01)
+_MOVEMENT_ENABLED = const(0x02)
+_HR_ENABLED = const(0x04)
+_GRADUAL_WAKE_ENABLED = const(0x08)
+_NAT_WAKE_ENABLED = const(0x10)
+_CURRENTLY_TRACKING = const(0x20)
+
+# App States 2 (8 bit register)
+_PAGE_MASK = const(0x03) # First 2 bits for 4 page states
+_PAGE_SHIFT = const(0)
+_META_STATE_MASK = const(0x0C) # Second 2 bits for 4 meta states
+_META_STATE_SHIFT = const(2) # Shift 2 bits over to read meta state
+_NUM_VIB_MASK = const(0xF0) # Last 4 bits for ring counter (max 16)
+_NUM_VIB_SHIFT = const(4)
+
+# App States 3 (8 bit register)
+_STOP_TRIAL_MASK = const(0x0F) # First 4 bits for stop trial (max 16)
+_STOP_TRIAL_SHIFT = const(0)
+_PREV_BRIGHT_MASK = const(0x30) # 2 bits for previous brightness level (max 4)
+_PREV_BRIGHT_SHIFT = const(4)
+_PREV_NOTE_MASK = const(0xC0) # 2 bits for previous notification level (max 4)
+_PREV_NOTE_SHIFT = const(6)
+
 
 class SleepTkApp():
     NAME = 'SleepTk'
@@ -106,48 +142,8 @@ class SleepTkApp():
     VERSION = const(1)
 
     def __init__(self):
-        # simple flag to init the variables only when the app is launched and
-        # not as soon as the app is loaded
-        self.was_inited = False
-
-    def _actual_init(self):
-        """lots of things to load so only load when the app is started instead
-        of directly when the watch is booted."""
-        wasp.gc.collect()
-
-        self._state_alarm = _ON
-        self._state_body_tracking = _ON
-        self._state_HR_tracking = _ON
-        self._state_gradual_wake = _ON
-        self._state_natwake = _OFF
-        # try to reload previous settings
-        if hasattr(wasp.system, "get") and callable(wasp.system.get):
-            try:
-                (
-                    self._state_alarm,
-                    self._state_body_tracking,
-                    self._state_HR_tracking,
-                    self._state_gradual_wake,
-                    self._state_natwake
-                    ) = [_ON if int(p) else _OFF
-                         for p in wasp.system.get("sleeptk_settings")]
-            except Exception:
-                pass
-
-        self._state_spinval_H = _OFF
-        self._state_spinval_M = _OFF
-        self._hrdata = None
-        self._last_HR = _OFF  # if _OFF, no HR to write, if "?": error during last HR, else: heart rate
-        self._last_HR_printed = "?"
-        self._last_HR_date = _OFF
-        self._track_HR_once = _OFF  # either _OFF or the timestamp of when the
-        # tracking is supposed to start
-        self._page = _SETTINGS1
-        self._currently_tracking = _OFF
-        self._conf_view = _OFF # confirmation view
-        self._buff = array("f", (_OFF, _OFF, _OFF)) # contains the sum of diff between each accel recordings and the previous recording, along each axis
-        self._last_touch = int(wasp.watch.rtc.time())
-
+        self._states = None
+        self._WU_t = None
         try:
             shell.mkdir("logs")
         except:  # folder already exists
@@ -157,70 +153,136 @@ class SleepTkApp():
         except:  # folder already exists
             pass
 
-        # used to indicate if the app is currently recording
-        wasp._SleepTk_tracking = _OFF
+    def _actual_init(self):
+        """lots of things to load so only load when the app is started instead
+        of directly when the watch is booted."""
+        self._states = bytearray(7)
 
-        wasp.gc.collect()
-        return True
+        # Init settings
+        self._set_bit_flag(_IDX_STATE_1, _ALARM_ENABLED, True)
+        self._set_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED, True)
+        self._set_bit_flag(_IDX_STATE_1, _HR_ENABLED, True)
+        self._set_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED, True)
+        self._set_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED, False)
+        self._set_bit_flag(_IDX_STATE_1, _CURRENTLY_TRACKING, False)
+        self._load_settings()
+
+        self._states[_IDX_LAST_HR] = _HEART_RATE_UNKNOWN
+        self._states[_IDX_LAST_HR_PRINTED] = _HEART_RATE_UNKNOWN
+
+        self._hrdata = None
+        self._last_HR_date = 0
+        self._track_HR_once = 0  # either 0 or the timestamp of when the
+        self._last_touch = int(wasp.watch.rtc.time())
+        self._conf_view = None # confirmation view
+        self._change_page(_PAGE_SETTINGS1)
+
+    def _change_page(self, new_page):
+        self._clean_up_page(self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT))
+        self._set_up_page(new_page)
+        self._set_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT, new_page)
+        self._draw()
+
+    def _set_up_page(self, page):
+        if page == _PAGE_SETTINGS1:
+            self._spin_H = widgets.Spinner(30, 70, 0, 23, 2)
+            self._spin_H.value = self._states[_IDX_ALARM_HOUR]
+            self._spin_M = widgets.Spinner(150, 70, 0, 59, 2, 5)
+            self._spin_M.value = self._states[_IDX_ALARM_MIN]
+            self._check_al = widgets.Checkbox(x=0, y=40, label="Wake me up")
+            self._check_al.state = self._states[_IDX_STATE_1] & _ALARM_ENABLED > 0
+        elif page == _PAGE_SETTINGS2:
+            self._check_body_tracking = widgets.Checkbox(x=0, y=40, label="Movement track")
+            self._check_body_tracking.state = self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED)
+            self._btn_HR = widgets.Checkbox(x=0, y=80, label="Heart rate track")
+            self._btn_HR.state = self._get_bit_flag(_IDX_STATE_1, _HR_ENABLED)
+            self._check_grad = widgets.Checkbox(0, 120, "Gradual wake")
+            self._check_grad.state = self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED)
+            self._check_natwake = widgets.Checkbox(0, 160, "Natural wake")
+            self._check_natwake.state = self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED)
+            self._btn_sta = widgets.Button(x=0, y=200, w=240, h=40, label="Start")
+        elif page == _PAGE_RINGING:
+            self._btn_snooz = widgets.Button(x=0, y=90, w=240, h=120, label="SNOOZE")
+        elif page == _PAGE_SLEEPING:
+            self._btn_off = widgets.Button(x=0, y=200, w=240, h=40, label="Stop")
+
+    def _clean_up_page(self, page):
+        if page == _PAGE_SETTINGS1:
+            self._spin_H = None
+            self._spin_M = None
+            self._check_al = None
+            del self._spin_H, self._spin_M, self._check_al
+        elif page == _PAGE_SETTINGS2:
+            self._check_body_tracking = None
+            self._btn_HR = None
+            self._check_grad = None
+            self._check_natwake = None
+            self._btn_sta = None
+            del self._check_body_tracking, self._btn_HR, self._check_grad, self._check_natwake, self._btn_sta
+        elif page == _PAGE_RINGING:
+            self._btn_snooz = None
+            del self._btn_snooz
+        elif page == _PAGE_SLEEPING:
+            self._conf_view = None
+            self._btn_off = None
+            del self._btn_off
 
     def foreground(self):
-        if not self.was_inited:
-            self.was_inited = self._actual_init()
+        if not self._states:
+            self._actual_init()
 
-        self.stat_bar = widgets.StatusBar()
-        self.stat_bar.clock = True
-        self.stat_bar.draw()
-        self._conf_view = _OFF
-        wasp.gc.collect()
+        self._draw_system_bar()
+        self._conf_view = None
         self._draw()
         wasp.system.request_event(wasp.EventMask.TOUCH |
                                   wasp.EventMask.SWIPE_LEFTRIGHT |
                                   wasp.EventMask.SWIPE_UPDOWN |
                                   wasp.EventMask.BUTTON)
-        if self._page == _SLEEPING and self._track_HR_once:
+        if self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT) == _PAGE_SLEEPING and self._track_HR_once:
             wasp.system.request_tick(1000 // 8)
 
     def sleep(self):
-        self._stop_trial = 0
-        wasp.gc.collect()
-        return True
+        self._set_shifted_int(_IDX_STATE_3, _STOP_TRIAL_MASK, _STOP_TRIAL_SHIFT, 0)
 
     def background(self):
         wasp.watch.hrs.disable()
         self._hrdata = None
-        self.stat_bar = None
-        if not hasattr(self, "_WU_t"):
-            # reinstanciate class to save memory
-            for i in range(len(wasp.system.launcher_ring)):
-                if wasp.system.launcher_ring[i].NAME == "SleepTk":
-                    wasp.system.launcher_ring[i] = SleepTkApp()
-                    break
+
+        # If not tracking de-initialize the app
+        if not self._get_bit_flag(_IDX_STATE_1, _CURRENTLY_TRACKING):
+            self._clean_up_page(self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT))
+            self._buff = None
+            del self._buff
+            self._states = None
+
+        if not self._WU_t:
             # also removes possible reference to the previous class
             wasp.system.cancel_alarm(None, self._activate_ticks_to_ring)
             wasp.system.cancel_alarm(None, self._start_natural_wake)
             wasp.system.cancel_alarm(None, self._trackOnce)
             wasp.system.cancel_alarm(None, self._tiny_vibration)
+
         wasp.gc.collect()
 
     def _try_stop_alarm(self):
         """If button or swipe more than _STOP_LIMIT, then stop ringing"""
-        if self._stop_trial + 1 >= _STOP_LIMIT:
-            self._n_vibration = 0
+        stop_trial = self._get_shifted_int(_IDX_STATE_3, _STOP_TRIAL_MASK, _STOP_TRIAL_SHIFT)
+        if stop_trial + 1 >= _STOP_LIMIT:
+            self._set_shifted_int(_IDX_STATE_3, _NUM_VIB_MASK, _NUM_VIB_SHIFT, 0)
             wasp.system.cancel_alarm(None, self._activate_ticks_to_ring)
             wasp.system.cancel_alarm(None, self._start_natural_wake)
             self._stop_tracking()
             self._WU_t = None
             del self._WU_t
 
-            # reset app:
-            self.__init__()
+            self._change_page(_PAGE_SETTINGS1)
             self.foreground()
         else:
-            self._stop_trial += 1
+            self._set_shifted_int(_IDX_STATE_3, _STOP_TRIAL_MASK, _STOP_TRIAL_SHIFT, stop_trial + 1)
             draw = wasp.watch.drawable
             draw.set_font(_FONT)
             draw.set_color(_FONT_COLOR)
-            draw.string("{} to stop".format(_STOP_LIMIT - self._stop_trial), 0, 70)
+            draw.string("{} to stop".format(_STOP_LIMIT - stop_trial), 0, 70)
 
     def press(self, button, state):
         "stop ringing alarm if pressed physical button"
@@ -229,17 +291,17 @@ class SleepTkApp():
         self._last_touch = int(wasp.watch.rtc.time())
         wasp.watch.display.mute(False)
         wasp.watch.display.poweron()
-        if self._page == _RINGING:
+
+        page = self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT)
+        meta_state = self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT)
+        if page == _PAGE_RINGING:
             self._try_stop_alarm()
-        elif self._page == _SLEEPING:
-            self.stat_bar = widgets.StatusBar()
-            self.stat_bar.clock = True
-            self.stat_bar.draw()
-            self.stat_bar.update()
-            if self._meta_state == 2:  # if gradual vibration
-                self._meta_state = 3  # also pressed
+        elif page == _PAGE_SLEEPING:
+            self._draw_system_bar()
+            if meta_state == 2:  # if gradual vibration
+                self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 3) # also pressed
             else:
-                self._meta_state = 1  # pressed
+                self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 1)  # pressed
             # disable pressing to exit, use swipe up instead
             self._draw()
         else:
@@ -250,39 +312,41 @@ class SleepTkApp():
         wasp.watch.display.mute(False)
         wasp.watch.display.poweron()
         self._last_touch = int(wasp.watch.rtc.time())
-        if self._page == _SETTINGS1:
+
+        page = self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT)
+        if page == _PAGE_SETTINGS1:
             if event[0] == wasp.EventType.LEFT:
-                self._page = _SETTINGS2
-                self._draw()
+                self._change_page(_PAGE_SETTINGS2)
             else:
                 return True
-        elif self._page == _SETTINGS2:
+        elif page == _PAGE_SETTINGS2:
             if event[0] == wasp.EventType.RIGHT:
-                self._page = _SETTINGS1
-                self._draw()
+                self._change_page(_PAGE_SETTINGS1)
             else:
                 return True
-        elif self._page == _RINGING:
+        elif page == _PAGE_RINGING:
             self._try_stop_alarm()
         else:
             return True
 
     def touch(self, event):
         """either start trackign or disable it, draw the screen in all cases"""
-        wasp.gc.collect()
         draw = wasp.watch.drawable
         wasp.watch.display.mute(False)
         wasp.watch.display.poweron()
         draw.set_font(_FONT)
         self._last_touch = int(wasp.watch.rtc.time())
-        self.stat_bar.draw()
-        if self._page == _SLEEPING:
-            if self._meta_state == 2:  # if gradual vibration
-                self._meta_state = 3  # also touched
+        self._draw_system_bar()
+
+        page = self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT)
+        meta_state = self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT)
+        if page == _PAGE_SLEEPING:
+            if meta_state == 2:  # if gradual vibration
+                self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 3) # also touched
             else:
-                self._meta_state = 1  # touched
-            if self._conf_view == _OFF:
-                if self.btn_off.touch(event):
+                self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 1) # touched
+            if not self._conf_view:
+                if self._btn_off.touch(event):
                     self._conf_view = widgets.ConfirmationView()
                     self._conf_view.draw("Stop tracking?")
                     draw.reset()
@@ -291,11 +355,11 @@ class SleepTkApp():
                 if self._conf_view.touch(event):
                     if self._conf_view.value:
                         self._stop_tracking()
-                        self._page = _SETTINGS1
-                    self._conf_view = _OFF
+                        self._change_page(_PAGE_SETTINGS1)
+                    self._conf_view = None
                 draw.reset()
-        elif self._page == _RINGING:
-            if self.btn_snooz.touch(event):
+        elif page == _PAGE_RINGING:
+            if self._btn_snooz.touch(event):
                 if self._track_HR_once:  # if currently tracking HR, stop
                     self._track_HR_once = _OFF
                     self._hrdata = None
@@ -303,81 +367,81 @@ class SleepTkApp():
                 wasp.system.cancel_alarm(None, self._start_natural_wake)
                 wasp.system.cancel_alarm(None, self._activate_ticks_to_ring)
                 self._WU_t = int(wasp.watch.rtc.time()) + _SNOOZE_TIME
-                if self._state_natwake:
+                if self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED):
                     wasp.system.set_alarm(self._WU_t, self._start_natural_wake)
                 else:
                     wasp.system.set_alarm(self._WU_t, self._activate_ticks_to_ring)
-                self._page = _SLEEPING
+                self._change_page(_PAGE_SLEEPING)
                 wasp.system.sleep()
-        elif self._page == _SETTINGS1:
-            if self._state_alarm and (self._spin_H.touch(event) or self._spin_M.touch(event)):
-                if self._state_spinval_M == 0 and self._spin_M.value == 55:
+        elif page == _PAGE_SETTINGS1:
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED) and (self._spin_H.touch(event) or self._spin_M.touch(event)):
+                if self._states[_IDX_ALARM_MIN] == 0 and self._spin_M.value == 55:
                     self._spin_H.value -= 1
-                elif self._state_spinval_M == 55 and self._spin_M.value == 0:
+                elif self._states[_IDX_ALARM_MIN] == 55 and self._spin_M.value == 0:
                     self._spin_H.value += 1
                 if self._spin_H.value >= 24:
                     self._spin_H.value = 0
                 elif self._spin_H.value <= -1:
                     self._spin_H.value = 23
-                self._state_spinval_M = self._spin_M.value
+                self._states[_IDX_ALARM_MIN] = self._spin_M.value
                 self._spin_M.update()
-                self._state_spinval_H = self._spin_H.value
+                self._states[_IDX_ALARM_HOUR] = self._spin_H.value
                 self._spin_H.update()
                 self._draw_duration(draw)
                 return
-            elif self.check_al.touch(event):
-                self._state_alarm = self.check_al.state
-                self.check_al.update()
-                if self._state_alarm:
-                    self._state_spinval_M = self._spin_M.value
-                    self._state_spinval_H = self._spin_H.value
+            elif self._check_al.touch(event):
+                self._set_bit_flag(_IDX_STATE_1, _ALARM_ENABLED, self._check_al.state)
+                self._check_al.update()
+                if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
+                    self._states[_IDX_ALARM_MIN] = self._spin_M.value
+                    self._states[_IDX_ALARM_HOUR] = self._spin_H.value
                     self._spin_M.draw()
                     self._spin_H.draw()
                     self._draw_duration(draw)
                 else:
                     self._draw()
             return
-        elif self._page == _SETTINGS2:
-            if self._state_body_tracking:
-                if self.btn_HR.touch(event):
-                    self.btn_HR.draw()
-                    self._state_HR_tracking = self.btn_HR.state
+        elif page == _PAGE_SETTINGS2:
+            if self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED):
+                if self._btn_HR.touch(event):
+                    self._btn_HR.draw()
+                    self._set_bit_flag(_IDX_STATE_1, _HR_ENABLED, self._btn_HR.state)
                     return
-            if self._state_alarm:
-                if self.check_grad.touch(event):
-                    self._state_gradual_wake = self.check_grad.state
-                    self.check_grad.draw()
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
+                if self._check_grad.touch(event):
+                    self._set_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED, self._check_grad.state)
+                    self._check_grad.draw()
                     return
-                elif self.check_natwake.touch(event):
-                    self._state_natwake = self.check_natwake.state
-                    self.check_natwake.draw()
+                elif self._check_natwake.touch(event):
+                    self._set_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED, self._check_natwake.state)
+                    self._check_natwake.draw()
                     return
-            if self.btn_sta.touch(event):
+            if self._btn_sta.touch(event):
                 draw.fill()
                 draw.string("Loading", 0, 100)
                 self._start_tracking()
-            elif self.check_body_tracking.touch(event):
-                self._state_body_tracking = self.check_body_tracking.state
-                self.check_body_tracking.draw()
-                if not self._state_body_tracking:
-                    self._state_HR_tracking = _OFF
+            elif self._check_body_tracking.touch(event):
+                self._set_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED, self._check_body_tracking.state)
+                self._check_body_tracking.draw()
+                if not self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED):
+                    self._set_bit_flag(_IDX_STATE_1, _HR_ENABLED, False)
         self._draw()
 
     def _draw_duration(self, draw):
         """draws the part of the screen that displays duration as it is
         used both when setting the alarm and throughout the night
         """
-        if not hasattr(self, "_state_spinval_H"):
-            return
         draw.set_font(_FONT)
-        if self._page == _SETTINGS1:
-            duration = (self._read_time(self._state_spinval_H, self._state_spinval_M) - wasp.watch.rtc.time()) / 60
+
+        page = self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT)
+        if page == _PAGE_SETTINGS1:
+            duration = (self._read_time(self._states[_IDX_ALARM_HOUR], self._states[_IDX_ALARM_MIN]) - wasp.watch.rtc.time()) / 60
             percent_str = ""
             y = 180
-        elif self._page == _SLEEPING:
+        elif page == _PAGE_SLEEPING:
             draw.set_color(_FONT_COLOR)
             duration = (wasp.watch.rtc.time() - self._track_start_time) / 60
-            if self._state_alarm:
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
                 percent = (wasp.watch.rtc.time() - self._track_start_time) / (self._WU_t - self._track_start_time)
                 percent_str = " ({:02d}%)".format(int(percent * 100))
             else:
@@ -409,148 +473,129 @@ class SleepTkApp():
         wasp.watch.display.poweron()
         draw = wasp.watch.drawable
         draw.fill(0)
-        self.stat_bar.draw()
+        self._draw_system_bar()
         draw.set_font(_FONT)
         draw.set_color(_FONT_COLOR)
-        if self._page == _RINGING:
+
+        page = self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT)
+        if page == _PAGE_RINGING:
             ti = wasp.watch.time.localtime(self._WU_t)
             draw.string("WAKE UP - {:02d}:{:02d}".format(ti[3], ti[4]), 0, 50)
-            self.btn_snooz = widgets.Button(x=0, y=90, w=240, h=120, label="SNOOZE")
-            self.btn_snooz.draw()
+            self._btn_snooz.draw()
             draw.reset()
-        elif self._page == _SLEEPING:
+        elif page == _PAGE_SLEEPING:
             ti_start = wasp.watch.time.localtime(self._track_start_time)
-            if self._state_alarm:
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
                 ti_stop = wasp.watch.time.localtime(self._WU_t)
                 draw.string('{:02d}:{:02d}  ->|  {:02d}:{:02d}'.format(ti_start[3], ti_start[4], ti_stop[3], ti_stop[4]), 0, 50)
-                if self._state_gradual_wake and self._state_natwake:
+                if self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED) and self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED):
                     draw.string("(Grad&Nat wake)", 0, 70)
-                elif self._state_gradual_wake:
+                elif self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED):
                     draw.string("(Gradual wake)", 0, 70)
-                elif self._state_natwake:
+                elif self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED):
                     draw.string("(Natural wake)", 0, 70)
             else:
                 draw.string('{:02d}:{:02d}  ->  ??'.format(ti_start[3], ti_start[4]), 0, 50)
-            #draw.string("data points: {} / {}".format(str(self._data_point_nb), str(self._data_point_nb * _FREQ // _STORE_FREQ)), 0, 110)
+
             if self._track_HR_once:
                 draw.string("(ongoing)", 0, 170)
-            if self._state_HR_tracking:
-                draw.string("HR:{}".format(self._last_HR_printed), 160, 170)
-            self.btn_off = widgets.Button(x=0, y=200, w=240, h=40, label="Stop")
-            self.btn_off.update(txt=_FONT_COLOR, frame=0, bg=0)
+            if self._get_bit_flag(_IDX_STATE_1, _HR_ENABLED):
+                draw.string("HR:{}".format(self._states[_IDX_LAST_HR_PRINTED]), 160, 170)
+            self._btn_off.update(txt=_FONT_COLOR, frame=0, bg=0)
             self._draw_duration(draw)
-        elif self._page == _SETTINGS1:
+        elif page == _PAGE_SETTINGS1:
             # reset spinval values between runs
-            self._state_spinval_H = _OFF
-            self._state_spinval_M = _OFF
-            self.check_al = widgets.Checkbox(x=0, y=40, label="Wake me up")
-            self.check_al.state = self._state_alarm
-            self.check_al.draw()
-            if self._state_alarm:
-                if (self._state_spinval_H, self._state_spinval_M) == (_OFF, _OFF):
-                    # suggest wake up time, on the basis of desired sleep goal + time to fall asleep
-                    (H, M) = wasp.watch.rtc.get_localtime()[3:5]
-                    goal_h = _SLEEP_GOAL_CYCLE * _CYCLE_LENGTH // 60
-                    goal_m = _SLEEP_GOAL_CYCLE * _CYCLE_LENGTH % 60
-                    M += goal_m
-                    while M % 5 != 0:
-                        M += 1
-                    self._state_spinval_H = ((H + goal_h) % 24 + (M // 60)) % 24
-                    self._state_spinval_M = M % 60
-                self._spin_H = widgets.Spinner(30, 70, 0, 23, 2)
-                self._spin_H.value = self._state_spinval_H
+            self._check_al.state = self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED)
+            self._check_al.draw()
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
+                # suggest wake up time, on the basis of desired sleep goal + time to fall asleep
+                (H, M) = wasp.watch.rtc.get_localtime()[3:5]
+                goal_h = _SLEEP_GOAL_CYCLE * _CYCLE_LENGTH // 60
+                goal_m = _SLEEP_GOAL_CYCLE * _CYCLE_LENGTH % 60
+                M += goal_m
+                while M % 5 != 0:
+                    M += 1
+                self._states[_IDX_ALARM_HOUR] = ((H + goal_h) % 24 + (M // 60)) % 24
+                self._states[_IDX_ALARM_MIN] = M % 60
+
+                self._spin_H.value = self._states[_IDX_ALARM_HOUR]
                 self._spin_H.draw()
-                self._spin_M = widgets.Spinner(150, 70, 0, 59, 2, 5)
-                self._spin_M.value = self._state_spinval_M
+                self._spin_M.value = self._states[_IDX_ALARM_MIN]
                 self._spin_M.draw()
-                if self._state_alarm:
+                if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
                     self._draw_duration(draw)
-        elif self._page == _SETTINGS2:
-            self.check_body_tracking = widgets.Checkbox(x=0, y=40, label="Movement tracking")
-            self.check_body_tracking.state = self._state_body_tracking
-            self.check_body_tracking.draw()
-            if self._state_body_tracking:
-                self.btn_HR = widgets.Checkbox(x=0, y=80, label="Heart rate tracking")
-                self.btn_HR.state = self._state_HR_tracking
-                self.btn_HR.draw()
-            if self._state_alarm:
-                self.check_grad = widgets.Checkbox(0, 120, "Gradual wake")
-                self.check_grad.state = self._state_gradual_wake
-                self.check_grad.draw()
-                self.check_natwake = widgets.Checkbox(0, 160, "Natural wake")
-                self.check_natwake.state = self._state_natwake
-                self.check_natwake.draw()
-            self.btn_sta = widgets.Button(x=0, y=200, w=240, h=40, label="Start")
-            self.btn_sta.draw()
+        elif page == _PAGE_SETTINGS2:
+            self._check_body_tracking.state = self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED)
+            self._check_body_tracking.draw()
+            if self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED):
+                self._btn_HR.state = self._get_bit_flag(_IDX_STATE_1, _HR_ENABLED)
+                self._btn_HR.draw()
+            if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
+                self._check_grad.state = self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED)
+                self._check_grad.draw()
+                self._check_natwake.state = self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED)
+                self._check_natwake.draw()
+            self._btn_sta.draw()
         draw.reset()
 
     def _start_tracking(self):
-        # save some memory
-        self.check_al = None
-        self.check_body_tracking = None
-        self.check_grad = None
-        self.check_natwake = None
-        self.btn_sta = None
-        self.btn_snooz = None
-        self.btn_off = None
-        self.btn_HR = None
-        self._spin_H = None
-        self._spin_M = None
-        del self.check_al, self.check_body_tracking, self.check_grad, self.check_natwake, self.btn_sta, self.btn_snooz, self.btn_off, self.btn_HR, self._spin_H, self._spin_M
-
-        self._currently_tracking = True
+        self._set_bit_flag(_IDX_STATE_1, _CURRENTLY_TRACKING, True)
 
         # accel data not yet written to disk:
         self._data_point_nb = 0  # total number of data points so far
         self._latest_save =  -1  # multiple of the saving frequency elapsed since start
         self._last_checkpoint = 0  # to know when to save to file
         self._track_start_time = int(wasp.watch.rtc.time())  # makes output more compact
-        self._last_HR_printed = "?"
-        self._meta_state = 0
+        self._next_track_time = None
+
+        self._states[_IDX_LAST_HR_PRINTED] = _HEART_RATE_UNKNOWN
+        self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 0)
         wasp.watch.accel.reset()
+
         xyz = wasp.watch.accel.accel_xyz()
         self._accel_memory = array("f",
             (xyz[0], xyz[1], xyz[2]))  # contains previous accelerometer value
+        self._buff = array("f", (0, 0, 0)) # contains the sum of diff between each accel recordings and the previous recording, along each axis
 
         # if enabled, add alarm to log accel data in _FREQ seconds
-        if self._state_body_tracking:
+        if self._get_bit_flag(_IDX_STATE_1, _MOVEMENT_ENABLED):
             # create one file per recording session:
             self.filep = "logs/sleep/{}_{}_{}.csv".format(str(self._track_start_time + _TIMESTAMP), _STORE_FREQ, self.VERSION)
             with open(self.filep, "wb") as f:
                 f.write("Timestamp,Motion,BPM,Meta".encode("ascii"))
-            self.next_track_time = wasp.watch.rtc.time() + _FREQ
-            wasp.system.set_alarm(self.next_track_time, self._trackOnce)
+            self._next_track_time = wasp.watch.rtc.time() + _FREQ
+            wasp.system.set_alarm(self._next_track_time, self._trackOnce)
         else:
-            self.next_track_time = None
+            self._next_track_time = None
 
-        if (self._state_gradual_wake or self._state_natwake) and not self._state_alarm:
+        if (self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED) or self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED)) and not self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
             # fix incompatible settings
-            self._state_gradual_wake = _OFF
-            self._state_natwake = _OFF
+            self._set_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED, False)
+            self._set_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED, False)
 
         # setting up alarm
-        if self._state_alarm:
+        if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED):
             self._old_notification_level = wasp.system.notify_level
-            self._WU_t = self._read_time(self._state_spinval_H, self._state_spinval_M)
-            if self._state_natwake:
+            self._WU_t = self._read_time(self._states[_IDX_ALARM_HOUR], self._states[_IDX_ALARM_MIN])
+            if self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED):
                 wasp.system.set_alarm(self._WU_t, self._start_natural_wake)
             else:
                 wasp.system.set_alarm(self._WU_t, self._activate_ticks_to_ring)
 
             # also set alarm to vibrate a tiny bit before wake up time
             # to wake up gradually
-            if self._state_gradual_wake:
+            if self._get_bit_flag(_IDX_STATE_1, _GRADUAL_WAKE_ENABLED):
                 for t in _GRADUAL_WAKE:
                     wasp.system.set_alarm(self._WU_t - int(t*60), self._tiny_vibration)
         else:
             self._WU_t = 0  # this is just to avoid the app overwriting itself when going in the background
 
         # reduce brightness
-        self._old_brightness_level = wasp.system.brightness
+        self._set_shifted_int(_IDX_STATE_3, _PREV_BRIGHT_MASK, _PREV_BRIGHT_SHIFT, wasp.system.brightness)
         wasp.system.brightness = 1
 
         # don't track heart rate right away, wait a few seconds
-        if self._state_HR_tracking:
+        if self._get_bit_flag(_IDX_STATE_1, _HR_ENABLED):
             self._last_HR_date = int(wasp.watch.rtc.time()) + 10
         wasp.system.notify_level = 1  # silent notifications
 
@@ -560,49 +605,53 @@ class SleepTkApp():
             if ble.enabled():
                 ble.disable()
 
-        self._page = _SLEEPING
-        self._stop_trial = 0
-        wasp._SleepTk_tracking = _ON
+        self._change_page(_PAGE_SLEEPING)
+        self._set_shifted_int(_IDX_STATE_3, _STOP_TRIAL_MASK, _STOP_TRIAL_SHIFT, 0)
 
         # save settings as future defaults
-        if hasattr(wasp.system, "set") and callable(wasp.system.set):
-            wasp.system.set("sleeptk_settings",
-                    [self._state_alarm,
-                     self._state_body_tracking,
-                     self._state_HR_tracking,
-                     self._state_gradual_wake,
-                     self._state_natwake
-                     ])
+        self._save_settings()
 
     def _read_time(self, HH, MM):
         "convert time from spinners to seconds"
         (Y, Mo, d, h, m) = wasp.watch.rtc.get_localtime()[0:5]
-        HH = self._state_spinval_H
-        MM = self._state_spinval_M
+        HH = self._states[_IDX_ALARM_HOUR]
+        MM = self._states[_IDX_ALARM_MIN]
         if HH < h or (HH == h and MM <= m):
             d += 1
         return wasp.watch.time.mktime((Y, Mo, d, HH, MM, 0, 0, 0, 0))
 
     def _stop_tracking(self, keep_main_alarm=False):
         """called by touching "STOP TRACKING" or when battery is low"""
-        self._currently_tracking = False
-        if self.next_track_time:
+        self._set_bit_flag(_IDX_STATE_1, _CURRENTLY_TRACKING, False)
+        if self._next_track_time:
             wasp.system.cancel_alarm(None, self._trackOnce)
-        if self._state_alarm and not keep_main_alarm:
+        if self._get_bit_flag(_IDX_STATE_1, _ALARM_ENABLED) and not keep_main_alarm:
             # to keep the alarm when stopping because of low battery
             wasp.system.cancel_alarm(None, self._start_natural_wake)
             wasp.system.cancel_alarm(None, self._activate_ticks_to_ring)
             wasp.system.cancel_alarm(None, self._tiny_vibration)
         wasp.watch.hrs.disable()
         self._periodicSave()
-        wasp._SleepTk_tracking = _OFF
+
+        # Clean up vars only used while tracking
+        self._buff = None
+        self._accel_memory = None
+        self._data_point_nb = None
+        self._latest_save =  None
+        self._last_checkpoint = None
+        self._track_start_time = None
+        self._next_track_time = None
+        del self._buff, self._accel_memory, self._data_point_nb, self._latest_save, self._last_checkpoint, self._track_start_time, self._next_track_time
+
+        self._change_page(_PAGE_SETTINGS1)
+
         wasp.gc.collect()
 
     def _trackOnce(self):
         """get one data point of accelerometer every _FREQ seconds, keep
         the diff of each axis then store in a file every
         _STORE_FREQ seconds"""
-        if self._currently_tracking:
+        if self._get_bit_flag(_IDX_STATE_1, _CURRENTLY_TRACKING):
             buff = self._buff
             xyz = wasp.watch.accel.accel_xyz()
             if xyz == (0, 0, 0):
@@ -615,8 +664,8 @@ class SleepTkApp():
             self._data_point_nb += 1
 
             # add alarm to log accel data in _FREQ seconds
-            self.next_track_time = wasp.watch.rtc.time() + _FREQ
-            wasp.system.set_alarm(self.next_track_time, self._trackOnce)
+            self._next_track_time = wasp.watch.rtc.time() + _FREQ
+            wasp.system.set_alarm(self._next_track_time, self._trackOnce)
 
             self._periodicSave()
             if wasp.watch.battery.level() <= _BATTERY_THRESHOLD and ((not hasattr(wasp, "_is_in_simulation")) or wasp._is_in_simulation is False):
@@ -634,7 +683,7 @@ class SleepTkApp():
                 if ble.enabled():
                     ble.disable()
                 del ble
-            elif self._state_HR_tracking and \
+            elif self._get_bit_flag(_IDX_STATE_1, _HR_ENABLED) and \
                     wasp.watch.rtc.time() - self._last_HR_date > _HR_FREQ and \
                     not self._track_HR_once:
                 self._track_HR_once = int(wasp.watch.rtc.time())
@@ -644,8 +693,6 @@ class SleepTkApp():
                     wasp.watch.display.poweroff()
                 wasp.system.switch(self)
                 wasp.system.request_tick(1000 // 8)
-
-        wasp.gc.collect()
 
     def _periodicSave(self):
         """save data to csv with row order:
@@ -661,11 +708,7 @@ class SleepTkApp():
                      2 if gradual vibration happened or natural wake
                      3 if pressed or touched after gradual vibration
         """
-        # fix the status bar never updating
-        self.stat_bar = widgets.StatusBar()
-        self.stat_bar.clock = True
-        self.stat_bar.draw()
-        self.stat_bar.update()
+        self._draw_system_bar()
 
         buff = self._buff
         n = self._data_point_nb - self._last_checkpoint
@@ -673,17 +716,19 @@ class SleepTkApp():
             # if for some reason we are still trying to compute the
             # heart rate after 60s, something went wrong and saving motion
             # data is more important so cancelling this tracking
-            self._track_HR_once = _OFF
+            self._track_HR_once = 0
         if n >= _STORE_FREQ // _FREQ and not self._track_HR_once:
-            if self._last_HR != _OFF:
-                bpm = self._last_HR
-                self._last_HR = _OFF
+            if self._states[_IDX_LAST_HR] != 0:
+                bpm = self._states[_IDX_LAST_HR]
+                self._states[_IDX_LAST_HR] = 0
+            elif self._states[_IDX_LAST_HR] == _HEART_RATE_UNKNOWN:
+                bpm = "?"
             else:
                 bpm = ""  # save a character if no value to print
-            if self._meta_state == 0:
+            if self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT) == 0:
                 meta = ""
             else:
-                meta = self._meta_state
+                meta = self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT)
             fac = 2 * math.pi / 2000 / n * 1000  # conversion factor
             motion = math.atan(
                     (buff[2] * fac) / (
@@ -706,26 +751,24 @@ class SleepTkApp():
                     meta,
                     ).encode("ascii"))
             # reset buffer
-            buff = array("f", (_OFF, _OFF, _OFF))
+            self._buff = array("f", (0, 0, 0))
             wasp.watch.accel.reset()
             self._last_checkpoint = self._data_point_nb
-            self._meta_state = 0
-            wasp.gc.collect()
+            self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 0)
 
     def _activate_ticks_to_ring(self):
         """listen to ticks every second, telling the watch to vibrate and
         completely wake the user up"""
-        if not hasattr(self, "_WU_t") or self._WU_t is None:
+        if self._WU_t is None:
             # alarm was already started and stopped
             return
         wasp.system.wake()
         wasp.system.switch(self)
-        self._page = _RINGING
-        self._n_vibration = 0
+        self._change_page(_PAGE_RINGING)
+        self._set_shifted_int(_IDX_STATE_2, _NUM_VIB_MASK, _NUM_VIB_SHIFT, 0)
         wasp.system.request_tick(period_ms=1000)
-        wasp.system.notify_level = self._old_notification_level  # restore notification level
-        wasp.system.brightness = self._old_brightness_level
-        wasp.gc.collect()
+        wasp.system.notify_level = self._get_shifted_int(_IDX_STATE_3, _PREV_NOTE_MASK, _PREV_NOTE_SHIFT)  # restore notification level
+        wasp.system.brightness = self._get_shifted_int(_IDX_STATE_3, _PREV_BRIGHT_MASK, _PREV_BRIGHT_MASK)
         if abs(int(wasp.watch.rtc.time()) - self._last_touch) > 5:
             wasp.watch.display.mute(True)
             wasp.watch.display.poweroff()
@@ -733,32 +776,31 @@ class SleepTkApp():
 
     def _start_natural_wake(self):
         """do a tiny vibration every 30s until the user wakes up"""
-        if not hasattr(self, "_WU_t") or self._WU_t is None:
+        if self._WU_t is None:
             # alarm was already started and stopped
             return
         wasp.system.wake()
         wasp.system.switch(self)
-        wasp.gc.collect()
 
         # cancel alarm then set to of them to make sure it does not skip one
         wasp.system.cancel_alarm(None, self._start_natural_wake)
         self._WU_t = wasp.watch.rtc.time() + _NATURAL_WAKE_IVL
         wasp.system.set_alarm(self._WU_t, self._start_natural_wake)
-        self._page = _RINGING
+        self._change_page(_PAGE_RINGING)
 
-        wasp.system.notify_level = self._old_notification_level
-        wasp.system.brightness = self._old_brightness_level
-        self._n_vibration = 0
+        wasp.system.notify_level = self._get_shifted_int(_IDX_STATE_3, _PREV_NOTE_MASK, _PREV_NOTE_SHIFT)
+        wasp.system.brightness = self._get_shifted_int(_IDX_STATE_3, _PREV_BRIGHT_MASK, _PREV_BRIGHT_MASK)
+        self._set_shifted_int(_IDX_STATE_2, _NUM_VIB_MASK, _NUM_VIB_SHIFT, 0)
         if abs(int(wasp.watch.rtc.time()) - self._last_touch) > 5:
             wasp.watch.display.mute(True)
             wasp.watch.display.poweroff()
 
         # tiny vibration
         wasp.watch.vibrator.pulse(duty=3, ms=50)
-        if self._meta_state == 1:  # if pressed or touched
-            self._meta_state = 3  # because also pressed
+        if self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT) == 1:  # if pressed or touched
+            self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 3)  # because also pressed
         else:
-            self._meta_state = 2  # gradual vibration
+            self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 2) # gradual vibration
         self._draw()
 
         if not self._track_HR_once:
@@ -768,14 +810,13 @@ class SleepTkApp():
 
     def tick(self, ticks):
         """vibrate to wake you up OR track heart rate using code from heart.py"""
-        wasp.gc.collect()
         wasp.system.switch(self)
-        if self._page == _RINGING and self._state_natwake == _OFF:
+        if self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT) == _PAGE_RINGING and not self._get_bit_flag(_IDX_STATE_1, _NAT_WAKE_ENABLED):
             wasp.system.keep_awake()
             # in 60 vibrations, ramp up from subtle to strong:
             wasp.watch.vibrator.pulse(duty=max(80 - 1 * self._n_vibration, 20),
                                       ms=min(100 + 6 * self._n_vibration, 500))
-            self._n_vibration += 1
+            self._set_shifted_int(_IDX_STATE_2, _NUM_VIB_MASK, _NUM_VIB_SHIFT, self._get_shifted_int(_IDX_STATE_2, _NUM_VIB_MASK, _NUM_VIB_SHIFT) + 1)
         elif self._track_HR_once:
             wasp.watch.hrs.enable()
             if self._hrdata is None:
@@ -805,19 +846,19 @@ class SleepTkApp():
                 if bpm is None:
                     # in case of invalid data, write it in the file but
                     # keep trying to read HR
-                    self._last_HR = "?"
+                    self._states[_IDX_LAST_HR] = _HEART_RATE_UNKNOWN
                     self._hrdata = None
-                    self._last_HR_printed = self._last_HR
+                    self._states[_IDX_LAST_HR_PRINTED] = self._states[_IDX_LAST_HR]
                 elif bpm < 100 and bpm > 40:
                     # if HR was already computed since last periodicSave,
                     # then average the two values
-                    if self._last_HR != _OFF and self._last_HR != "?" and isinstance(int, self._last_HR):
-                        self._last_HR = (self._last_HR + bpm) // 2
+                    if self._states[_IDX_LAST_HR] != _HEART_RATE_UNKNOWN:
+                        self._states[_IDX_LAST_HR] = (self._states[_IDX_LAST_HR] + bpm) // 2
                     else:
-                        self._last_HR = bpm
-                    self._last_HR_printed = self._last_HR
+                        self._states[_IDX_LAST_HR] = bpm
+                    self._states[_IDX_LAST_HR_PRINTED] = elf._states[_IDX_LAST_HR]
                     self._last_HR_date = int(wasp.watch.rtc.time())
-                    self._track_HR_once = _OFF
+                    self._track_HR_once = None
                     self._hrdata = None
                     wasp.watch.hrs.disable()
                     if abs(int(wasp.watch.rtc.time()) - self._last_touch) > 5:
@@ -830,19 +871,47 @@ class SleepTkApp():
     def _tiny_vibration(self):
         """vibrate just a tiny bit before waking up, to gradually return
         to consciousness"""
-        wasp.gc.collect()
         if abs(int(wasp.watch.rtc.time()) - self._last_touch) > 5:
             wasp.watch.display.mute(True)
             wasp.watch.display.poweroff()
         wasp.system.wake()
         wasp.system.switch(self)
-        if self._page != _RINGING:  # safeguard: don't vibrate anymore if already on ringing page
+        if self._get_shifted_int(_IDX_STATE_2, _PAGE_MASK, _PAGE_SHIFT) != _PAGE_RINGING:  # safeguard: don't vibrate anymore if already on ringing page
             wasp.watch.vibrator.pulse(duty=3, ms=50)
-            # time.sleep(0.1)
-            # wasp.watch.vibrator.pulse(duty=3, ms=50)
-        if self._meta_state == 1:  # if pressed or touched
-            self._meta_state = 3  # because also pressed
+        if self._get_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT) == 1:  # if pressed or touched
+            self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 3)  # because also pressed
         else:
-            self._meta_state = 2  # gradual vibration
+            self._set_shifted_int(_IDX_STATE_2, _META_STATE_MASK, _META_STATE_SHIFT, 2) # gradual vibration
         if not self._track_HR_once:
             wasp.system.sleep()
+
+    def _load_settings(self):
+        if hasattr(wasp.system, "get") and callable(wasp.system.get):
+            try:
+                self._states[_IDX_STATE_1] = wasp.system.get("sleeptk_settings")
+            except Exception:
+                pass
+
+    def _save_settings(self):
+        if hasattr(wasp.system, "set") and callable(wasp.system.set):
+            wasp.system.set("sleeptk_settings", self._states[_IDX_STATE_1])
+
+    def _draw_system_bar(self):
+            sbar = wasp.system.bar
+            sbar.clock = True
+            sbar.draw()
+
+    def _get_shifted_int(self, register_idx, bit_mask, bit_shift):
+        return (self._states[register_idx] & bit_mask) >> bit_shift
+
+    def _set_shifted_int(self, register_idx, bit_mask, bit_shift, value):
+        self._states[register_idx] = (self._states[register_idx] & bit_mask) | (value << bit_shift)
+
+    def _get_bit_flag(self, register_idx, bit_mask):
+        return self._states[register_idx] & bit_mask > 0
+
+    def _set_bit_flag(self, register_idx, bit_mask, new_state):
+        if new_state:
+            self._states[register_idx] = self._states[register_idx] | bit_mask
+        else:
+            self._states[register_idx] = self._states[register_idx] & ~bit_mask


### PR DESCRIPTION
Here is a memory optimized version of sleep TK. I tried to keep all your business logic the same and only change how memory is managed. I didnt have time to do anything more than smoke test and I'm not 100% sure of your business logic so please take the time to make sure I didnt break anything. If you need my help in understanding any of this code let me know and I am happy to help.

Reading your code I get the feeling you have been chasing and pushing around memory errors for a while. This was a very ambitious project for someone with no comp sci background. You clearly enjoy this kind of work and I think you have the skill set to be really good at it with some comp sci knowledge and more practice. I think what got you here is just not knowing how memory is managed and not having drawn out an app lifecycle diagram.

I dont have a ton of time to go into all the decisions I made here but I will try and give a basic overview so you know how to service this code and how to avoid these issues in the future.

- If you find yourself calling the GC outside of a cleanup method or find yourself recreating the entire app object thats a good sign you havent planned out the lifecycle of your app on paper. These solutions just push the errors around they dont fix them
- Member vars (vars on the self object) are expensive. If you can use a locally scooped var just in that method do it
- Have set points in the lifecycle where memory is allocated and released. In this case I chose when the page is created or destroyed and when tracking is started or stopped
- Dont reach into other systems to store data (the wasp._SleepTK_Tracking var). That data will end up just sitting around and other devs wont know it exists
- Instead of setting a var to 0 (_OFF) set it to None. Same end result but you save a full width integer
- I compacted all your bools into a byte with each bit representing one bool
- I compacted all your small ints into 2,4, or 8 bits depending on the max size
- All compacted data stored in a byte array
- I didnt modify how the time stamp vars or some of the other tracking vars holding large numbers are stored. I think these changes will open up enough memory for this app to play nice. but you could save a ton of memory by using small integers representing the number of periods passed instead of a full count of seconds. You could just add more bytes to the states array to store these offsets. I think your saving grace here is that the app really takes control of the entire watch when tracking so the user is not multitasking.
- I removed commented out code. Its bad practice to submit code will old commented code still present

Note that I changed how settings are saved. only one byte of data is needed. This is not compatible with old saves. I think that the first try will just fail and the first save will overwrite but I dont have this settings save code your using so for me it just skips that logic. You can save additional data besides the one byte by just saving any other byte in the states array. I think I kept your intent here but change is needed.

Also note that I think that when recording the movement you actually want the absolute value of the differences not the difference of the absolute values. That way u would get a graph where large numbers are more movement and small is less. Where as right now its more of a map of position. I didnt make that change because I wanted this PR to be refactoring only. But I think it would be better.


buff[0] += (abs(self._accel_memory[0]) - abs(xyz[0]))
buff[1] += (abs(self._accel_memory[1]) - abs(xyz[1]))
buff[2] += (abs(self._accel_memory[2]) - abs(xyz[2]))

change to

buff[0] += (abs(self._accel_memory[0] - xyz[0]))
buff[1] += (abs(self._accel_memory[0] - xyz[1]))
buff[2] += (abs(self._accel_memory[0] - xyz[2]))


And lastly I noticed that you have multiple page draws some times. That indicated that you code is looping over the change page or foreground method multiple times. I think that was because of your app reset logic which i removed. But I didnt go hunting down all these loops. It seems to work fine but the screen visually blanks multiple times. You could save some time in loading if you remove these loops.

